### PR TITLE
make sure `remote.bash` is writable

### DIFF
--- a/src/remote
+++ b/src/remote
@@ -97,6 +97,7 @@ function §remote.interface.create {
     local bookmarks="$bashrun_cache_home/remote-bookmarks.bash"
 
     /bin/cp "$bashrun_site/interface" "$interface"
+    chmod +w "$interface"
     printf '%s\n' "$bashrun_remote_interface" >> "$interface"
 
     printf '%s\n' "source $bindings" >> "$interface"


### PR DESCRIPTION
In some distributions, copying `share/bashrun2/remote.bash` into the cache directory may create a file without write permissions. This PR makes sure the write permission is set.